### PR TITLE
9 xp calculation calculated incorrectly

### DIFF
--- a/src/components/Char.tsx
+++ b/src/components/Char.tsx
@@ -60,14 +60,14 @@ const Char = ({
                 <li>
                     <b>Treasure:</b>{' '}
                     {character instanceof NPC
-                        ? (
+                        ? Math.round(
                               party.getGpPerShare() *
-                              party.shareToNum(
-                                  character.getShare(),
-                                  party.getPcShare()
-                              )
+                                  party.shareToNum(
+                                      character.getShare(),
+                                      party.getPcShare()
+                                  )
                           ).toLocaleString()
-                        : party.getGpPerPCShare().toLocaleString()}
+                        : Math.round(party.getGpPerPCShare()).toLocaleString()}
                     gp
                 </li>
             </ul>

--- a/src/components/Char.tsx
+++ b/src/components/Char.tsx
@@ -40,7 +40,8 @@ const Char = ({
                 </p>
             ) : (
                 <p>
-                    <b title="Total XP Needed">TXP:</b> {character.getTxp()}
+                    <b title="Total XP Needed">TXP:</b>{' '}
+                    {character.getTxp().toLocaleString()}
                 </p>
             )}
             <p>

--- a/src/components/Char.tsx
+++ b/src/components/Char.tsx
@@ -17,8 +17,8 @@ const Char = ({
     return (
         <div className="character mb-20">
             <h3>
-                {character.get_name()} ({character.get_char_class()}{' '}
-                {character.get_level()}
+                {character.getName()} ({character.getCharClass()}{' '}
+                {character.getLevel()}
                 {character instanceof NPC ? (
                     <>
                         , <span className="span-npc">NPC</span>
@@ -26,21 +26,21 @@ const Char = ({
                 ) : null}
                 )
             </h3>
-            {character.get_xp_mod() !== 0 ? (
+            {character.getXpMod() !== 0 ? (
                 <p>
-                    <b>XP Modifier:</b> {character.get_xp_mod() > 0 ? '+' : ''}
-                    {character.get_xp_mod()}%
+                    <b>XP Modifier:</b> {character.getXpMod() > 0 ? '+' : ''}
+                    {character.getXpMod()}%
                 </p>
             ) : null}
             {character instanceof NPC ? (
                 <p>
-                    <b>Daily wage:</b> {character.get_wage()}
-                    {character.get_wage_coin()}, <b>Shares of treasure:</b>{' '}
-                    {character.get_share()}
+                    <b>Daily wage:</b> {character.getWage()}
+                    {character.getWageCoin()}, <b>Shares of treasure:</b>{' '}
+                    {character.getShare()}
                 </p>
             ) : (
                 <p>
-                    <b title="Total XP Needed">TXP:</b> {character.get_txp()}
+                    <b title="Total XP Needed">TXP:</b> {character.getTxp()}
                 </p>
             )}
             <p>
@@ -51,9 +51,9 @@ const Char = ({
                     <b>XP:</b> +
                     {Math.round(
                         (character instanceof NPC
-                            ? party.get_xp_per_npc_share()
-                            : party.get_xp_per_pc_share()) *
-                            character.get_xp_mod_percentage()
+                            ? party.getXpPerNpcShare()
+                            : party.getXpPerPcShare()) *
+                            character.getXpModPercentage()
                     ).toLocaleString()}{' '}
                 </li>
                 <li>
@@ -61,9 +61,9 @@ const Char = ({
                     {character instanceof NPC
                         ? (
                               party.getGpPerShare() *
-                              party.share_to_num(
-                                  character.get_share(),
-                                  party.get_pc_share()
+                              party.shareToNum(
+                                  character.getShare(),
+                                  party.getPcShare()
                               )
                           ).toLocaleString()
                         : party.getGpPerPCShare().toLocaleString()}
@@ -73,14 +73,14 @@ const Char = ({
             <p>
                 <button
                     className="btn btn-inline"
-                    onClick={(e) => editCharacter(character.get_uuid())}
+                    onClick={(e) => editCharacter(character.getUuid())}
                 >
                     Edit
                 </button>{' '}
                 |{' '}
                 <button
                     className="btn btn-inline"
-                    onClick={(e) => removeCharacter(character.get_uuid())}
+                    onClick={(e) => removeCharacter(character.getUuid())}
                 >
                     Remove
                 </button>

--- a/src/components/CharacterForm.tsx
+++ b/src/components/CharacterForm.tsx
@@ -1,5 +1,5 @@
 import { FormEvent, useEffect, useState } from 'react'
-import { Char_Class } from '../service/Char_Class'
+import { CharClass } from '../service/CharClass'
 import { PC } from '../service/PC'
 import { Denomination } from '../service/Denomination'
 import { getEnumKeys } from '../service/EnumKeys'
@@ -21,7 +21,7 @@ const CharacterForm = ({
 }: CharacterFormProps) => {
     const [name, setName] = useState<string>('')
     const [level, setLevel] = useState<number>(1)
-    const [charClass, setCharClass] = useState<Char_Class>(Char_Class.cleric)
+    const [charClass, setCharClass] = useState<CharClass>(CharClass.cleric)
     const [xpMod, setXpMod] = useState<number>(0)
     const [pc, setPc] = useState<PC>(PC.pc)
 
@@ -39,15 +39,15 @@ const CharacterForm = ({
 
     useEffect(() => {
         if (character) {
-            setName(character.get_name())
-            setLevel(character.get_level())
-            setCharClass(character.get_char_class())
-            setXpMod(character.get_xp_mod())
+            setName(character.getName())
+            setLevel(character.getLevel())
+            setCharClass(character.getCharClass())
+            setXpMod(character.getXpMod())
             if (character instanceof NPC) {
                 setPc(PC.npc)
-                setWage(character.get_wage())
-                setWageCoin(character.get_wage_coin())
-                setShare(character.get_share())
+                setWage(character.getWage())
+                setWageCoin(character.getWageCoin())
+                setShare(character.getShare())
             } else {
                 setPc(PC.pc)
             }
@@ -57,7 +57,7 @@ const CharacterForm = ({
     let resetFields = () => {
         setName('')
         setLevel(1)
-        setCharClass(Char_Class.cleric)
+        setCharClass(CharClass.cleric)
         setXpMod(0)
         // setPc(PC.pc)
         setWage(1)
@@ -139,7 +139,7 @@ const CharacterForm = ({
                     charClass,
                     xpMod,
                     true,
-                    character?.get_uuid()
+                    character?.getUuid()
                 )
             } else {
                 char = new NPC(
@@ -150,7 +150,7 @@ const CharacterForm = ({
                     wage,
                     wageCoin,
                     share,
-                    character?.get_uuid()
+                    character?.getUuid()
                 )
             }
             resetFields()
@@ -222,10 +222,10 @@ const CharacterForm = ({
                 <select
                     value={charClass}
                     id="character-class"
-                    onChange={(e) => setCharClass(e.target.value as Char_Class)}
+                    onChange={(e) => setCharClass(e.target.value as CharClass)}
                 >
-                    {getEnumKeys(Char_Class).map((key, index) => (
-                        <option key={index} value={Char_Class[key]}>
+                    {getEnumKeys(CharClass).map((key, index) => (
+                        <option key={index} value={CharClass[key]}>
                             {capitalize(key)}
                         </option>
                     ))}

--- a/src/components/Home.tsx
+++ b/src/components/Home.tsx
@@ -1,6 +1,6 @@
 import { Party } from '../service/Party'
 import { Character, NPC } from '../service/Character'
-import { Coin_Treasure, Treasure } from '../service/Treasure'
+import { CoinTreasure, Treasure } from '../service/Treasure'
 import { Monster } from '../service/Monster'
 import Char from './Char'
 import PartyTreasure from './PartyTreasure'
@@ -21,7 +21,7 @@ const Home = () => {
         Character | NPC | undefined
     >(undefined)
     const [formTreasure, setFormTreasure] = useState<
-        Treasure | Coin_Treasure | undefined
+        Treasure | CoinTreasure | undefined
     >(undefined)
     const [formMonster, setFormMonster] = useState<Monster | undefined>(
         undefined
@@ -63,77 +63,77 @@ const Home = () => {
 
     let cloneParty = (): Party => {
         return new Party(
-            party.get_characters(),
-            party.get_treasure(),
-            party.get_monsters(),
-            party.get_feats(),
-            party.get_pc_share(),
-            party.get_num_shares(),
-            party.getXp_pc_share(),
-            party.getXp_num_shares()
+            party.getCharacters(),
+            party.getTreasure(),
+            party.getMonsters(),
+            party.getFeats(),
+            party.getPcShare(),
+            party.getNumShares(),
+            party.getXpPcShare(),
+            party.getXpNumShares()
         )
     }
 
     let add = (element: Character | Treasure | Monster | Feat) => {
-        let temp_party = cloneParty()
+        let tempParty = cloneParty()
         if (element instanceof Character) {
-            temp_party.add_character(element)
+            tempParty.addCharacter(element)
             setFormCharacter(undefined)
         } else if (element instanceof Treasure) {
-            temp_party.addTreasure(element)
+            tempParty.addTreasure(element)
             setFormTreasure(undefined)
         } else if (element instanceof Monster) {
-            temp_party.addMonster(element)
+            tempParty.addMonster(element)
             setFormMonster(undefined)
         } else if (element instanceof Feat) {
-            temp_party.addFeat(element)
+            tempParty.addFeat(element)
             setFormFeat(undefined)
         } else {
             console.error(`${element} is not permitted!`)
         }
-        setParty(temp_party)
+        setParty(tempParty)
         closeModal()
     }
 
     let edit = (element: Character | Treasure | Monster | Feat) => {
-        let temp_party = cloneParty()
+        let tempParty = cloneParty()
         if (element instanceof Character) {
-            temp_party.editCharacter(element)
+            tempParty.editCharacter(element)
             setFormCharacter(undefined)
         } else if (element instanceof Treasure) {
-            temp_party.editTreasure(element)
+            tempParty.editTreasure(element)
             setFormTreasure(undefined)
         } else if (element instanceof Monster) {
-            temp_party.editMonster(element)
+            tempParty.editMonster(element)
             setFormMonster(undefined)
         } else if (element instanceof Feat) {
-            temp_party.editFeat(element)
+            tempParty.editFeat(element)
             setFormFeat(undefined)
         } else {
             console.error(`${element} is not permitted!`)
         }
-        setParty(temp_party)
+        setParty(tempParty)
         closeModal()
     }
 
     let remove = (element: Character | Treasure | Monster | Feat) => {
-        let temp_party = cloneParty()
+        let tempParty = cloneParty()
         if (element instanceof Character) {
-            temp_party.remove_character_by_uuid(element.get_uuid())
+            tempParty.removeCharacterByUuid(element.getUuid())
             setFormCharacter(undefined)
         } else if (element instanceof Treasure) {
-            temp_party.removeTreasure(element.getUuid())
+            tempParty.removeTreasure(element.getUuid())
             setFormTreasure(undefined)
         } else if (element instanceof Monster) {
-            temp_party.removeMonster(element.getUuid())
+            tempParty.removeMonster(element.getUuid())
             setFormMonster(undefined)
         } else if (element instanceof Feat) {
-            temp_party.removeFeat(element.getUuid())
+            tempParty.removeFeat(element.getUuid())
             setFormFeat(undefined)
         } else {
             console.error(`${element} is not permitted!`)
         }
-        setParty(temp_party)
+        setParty(tempParty)
         closeModal()
     }
 
@@ -144,9 +144,9 @@ const Home = () => {
     let loadParty = (): void => {
         let myParty = JSON.parse(window.localStorage.getItem('party') || '""')
 
-        let temp_party = new Party()
-        temp_party.JSONparse(myParty)
-        setParty(temp_party)
+        let tempParty = new Party()
+        tempParty.JSONparse(myParty)
+        setParty(tempParty)
         setLoaded(true)
     }
 
@@ -248,24 +248,24 @@ const Home = () => {
                 </Modal>
             )}
 
-            {party.get_characters().length > 0 ? (
+            {party.getCharacters().length > 0 ? (
                 <>
                     <h2>
                         Total XP:{' '}
                         {(
-                            party.get_total_xp() + party.get_feat_xp()
+                            party.getTotalXp() + party.getFeatXp()
                         ).toLocaleString()}
                     </h2>
                     {party.getNumPC() > 0 ? (
                         <>
                             <p>
                                 <b>Party TXP:</b>{' '}
-                                {party.get_party_txp().toLocaleString()}
+                                {party.getPartyTxp().toLocaleString()}
                             </p>
                             <p>
                                 <b>Each PC gains:</b>{' '}
                                 {Math.round(
-                                    party.get_xp_per_pc_share()
+                                    party.getXpPerPcShare()
                                 ).toLocaleString()}{' '}
                                 XP, {party.getGpPerPCShare().toLocaleString()}gp
                             </p>
@@ -276,7 +276,7 @@ const Home = () => {
                             <p>
                                 <b>Each NPC gains:</b>{' '}
                                 {Math.round(
-                                    party.get_xp_per_npc_share()
+                                    party.getXpPerNpcShare()
                                 ).toLocaleString()}{' '}
                                 XP
                             </p>
@@ -306,10 +306,10 @@ const Home = () => {
                 </>
             ) : null}
 
-            {party.get_characters().length > 0 ? (
+            {party.getCharacters().length > 0 ? (
                 <div>
                     <h2>Characters:</h2>
-                    {party.get_characters().map((c) => (
+                    {party.getCharacters().map((c) => (
                         <Char
                             character={c}
                             party={party}
@@ -318,18 +318,18 @@ const Home = () => {
                                 setFormCharacter(c)
                                 setShowModal(Element.character)
                             }}
-                            key={c.get_uuid()}
+                            key={c.getUuid()}
                         />
                     ))}
                 </div>
             ) : null}
-            {party.get_treasure().length > 0 ? (
+            {party.getTreasure().length > 0 ? (
                 <div>
                     <h2>
                         Treasure found: (
-                        {party.get_treasure_xp().toLocaleString()} XP)
+                        {party.getTreasureXp().toLocaleString()} XP)
                     </h2>
-                    {party.get_treasure().map((t) => (
+                    {party.getTreasure().map((t) => (
                         <PartyTreasure
                             treasure={t}
                             removeTreasure={() => remove(t)}
@@ -342,13 +342,13 @@ const Home = () => {
                     ))}
                 </div>
             ) : null}
-            {party.get_monsters().length > 0 ? (
+            {party.getMonsters().length > 0 ? (
                 <div>
                     <h2>
                         Monsters defeated: (
-                        {party.get_monster_xp().toLocaleString()} XP)
+                        {party.getMonsterXp().toLocaleString()} XP)
                     </h2>
-                    {party.get_monsters().map((m) => (
+                    {party.getMonsters().map((m) => (
                         <MonsterDefeated
                             monster={m}
                             removeMonster={() => remove(m)}
@@ -361,16 +361,16 @@ const Home = () => {
                     ))}
                 </div>
             ) : null}
-            {party.get_feats().length > 0 ? (
+            {party.getFeats().length > 0 ? (
                 <div>
                     <h2>
                         Feats of Exploration (
-                        {party.get_feat_xp().toLocaleString()} XP)
+                        {party.getFeatXp().toLocaleString()} XP)
                     </h2>
-                    {party.get_feats().map((f) => (
+                    {party.getFeats().map((f) => (
                         <PartyFeat
                             feat={f}
-                            txp={party.get_party_txp()}
+                            txp={party.getPartyTxp()}
                             removeFeat={() => remove(f)}
                             editFeat={() => {
                                 setFormFeat(f)

--- a/src/components/MonsterDefeated.tsx
+++ b/src/components/MonsterDefeated.tsx
@@ -14,17 +14,17 @@ const MonsterDefeated = ({
     return (
         <div>
             <h3>
-                {monster.get_qty().toLocaleString()} {monster.get_name()}
+                {monster.getQty().toLocaleString()} {monster.getName()}
             </h3>
             <p>
-                {monster.get_description().length > 0 ? (
-                    <>{monster.get_description()}. </>
+                {monster.getDescription().length > 0 ? (
+                    <>{monster.getDescription()}. </>
                 ) : (
                     ''
                 )}
-                <b>XP</b>: {monster.get_xp().toLocaleString()}{' '}
-                {monster.get_qty() > 1 ? (
-                    <>each ({monster.get_total_xp().toLocaleString()} total)</>
+                <b>XP</b>: {monster.getXp().toLocaleString()}{' '}
+                {monster.getQty() > 1 ? (
+                    <>each ({monster.getTotalXp().toLocaleString()} total)</>
                 ) : (
                     ''
                 )}

--- a/src/components/MonsterForm.tsx
+++ b/src/components/MonsterForm.tsx
@@ -25,10 +25,10 @@ const MonsterForm = ({
 
     useEffect(() => {
         if (monster) {
-            setName(monster.get_name())
-            setDescription(monster.get_description())
-            setXp(monster.get_xp())
-            setQty(monster.get_qty())
+            setName(monster.getName())
+            setDescription(monster.getDescription())
+            setXp(monster.getXp())
+            setQty(monster.getQty())
         }
     }, [monster])
 

--- a/src/components/PartyTreasure.tsx
+++ b/src/components/PartyTreasure.tsx
@@ -1,4 +1,4 @@
-import { Coin_Treasure, Treasure } from '../service/Treasure'
+import { CoinTreasure, Treasure } from '../service/Treasure'
 
 interface PartyTreasureProps {
     treasure: Treasure
@@ -13,8 +13,8 @@ const PartyTreasure = ({
 }: PartyTreasureProps) => {
     return (
         <div>
-            {treasure instanceof Coin_Treasure ? (
-                <h3>{treasure.to_string()}</h3>
+            {treasure instanceof CoinTreasure ? (
+                <h3>{treasure.toString()}</h3>
             ) : (
                 <>
                     <h3>
@@ -37,9 +37,9 @@ const PartyTreasure = ({
                         {treasure.getWorth() > 0 ? (
                             <>
                                 (worth {treasure.getWorth().toLocaleString()}
-                                {treasure.getWorth_coin()}
+                                {treasure.getWorthCoin()}
                                 {treasure.getQty() > 1 ? (
-                                    <> {treasure.getWorth_determiner()}</>
+                                    <> {treasure.getWorthDeterminer()}</>
                                 ) : (
                                     ''
                                 )}

--- a/src/components/TreasureForm.tsx
+++ b/src/components/TreasureForm.tsx
@@ -1,5 +1,5 @@
 import { FormEvent, useEffect, useState } from 'react'
-import { Coin_Treasure, Treasure } from '../service/Treasure'
+import { CoinTreasure, Treasure } from '../service/Treasure'
 import { Determiner } from '../service/Determiner'
 import { Denomination } from '../service/Denomination'
 import { getEnumKeys } from '../service/EnumKeys'
@@ -9,10 +9,10 @@ interface TreasureFormProps {
     returnTreasure: (treasure: Treasure) => void
     returnEditTreasure: (treasure: Treasure) => void
     closeForm: () => void
-    treasure: Treasure | Coin_Treasure | undefined
+    treasure: Treasure | CoinTreasure | undefined
 }
 
-enum CoinTreasure {
+enum CoinOrTreasure {
     treasure = 'treasure',
     coins = 'coins',
 }
@@ -26,8 +26,8 @@ const TreasureForm = ({
     const [name, setName] = useState('')
     const [description, setDescription] = useState('')
     const [qty, setQty] = useState(1)
-    const [coinTreasure, setCoinTreasure] = useState<CoinTreasure>(
-        CoinTreasure.treasure
+    const [coinTreasure, setCoinTreasure] = useState<CoinOrTreasure>(
+        CoinOrTreasure.treasure
     )
     const [worth, setWorth] = useState(0)
     const [worthCoin, setWorthCoin] = useState<Denomination>(Denomination.gp)
@@ -42,15 +42,15 @@ const TreasureForm = ({
     useEffect(() => {
         if (treasure) {
             setQty(treasure.getQty())
-            setWorthCoin(treasure.getWorth_coin())
-            if (!(treasure instanceof Coin_Treasure)) {
-                setCoinTreasure(CoinTreasure.treasure)
+            setWorthCoin(treasure.getWorthCoin())
+            if (!(treasure instanceof CoinTreasure)) {
+                setCoinTreasure(CoinOrTreasure.treasure)
                 setName(treasure.getName())
                 setDescription(treasure.getDescription())
                 setWorth(treasure.getWorth())
-                setWorthDeterminer(treasure.getWorth_determiner())
+                setWorthDeterminer(treasure.getWorthDeterminer())
             } else {
-                setCoinTreasure(CoinTreasure.coins)
+                setCoinTreasure(CoinOrTreasure.coins)
             }
         }
     }, [treasure])
@@ -67,7 +67,7 @@ const TreasureForm = ({
     let validate = (): boolean => {
         let error = false
 
-        if (coinTreasure === CoinTreasure.treasure) {
+        if (coinTreasure === CoinOrTreasure.treasure) {
             if (name.length === 0) {
                 setIsNameError(true)
                 error = true
@@ -97,7 +97,7 @@ const TreasureForm = ({
         let error: boolean = validate()
         if (!error) {
             var treasure: Treasure
-            if (coinTreasure === CoinTreasure.treasure) {
+            if (coinTreasure === CoinOrTreasure.treasure) {
                 treasure = new Treasure(
                     name,
                     description,
@@ -107,7 +107,7 @@ const TreasureForm = ({
                     worthDeterminer
                 )
             } else {
-                treasure = new Coin_Treasure(qty, worthCoin)
+                treasure = new CoinTreasure(qty, worthCoin)
             }
 
             resetFields()
@@ -122,7 +122,7 @@ const TreasureForm = ({
 
         if (!error) {
             var newTreasure: Treasure
-            if (coinTreasure === CoinTreasure.treasure) {
+            if (coinTreasure === CoinOrTreasure.treasure) {
                 newTreasure = new Treasure(
                     name,
                     description,
@@ -133,7 +133,7 @@ const TreasureForm = ({
                     treasure?.getUuid()
                 )
             } else {
-                newTreasure = new Coin_Treasure(
+                newTreasure = new CoinTreasure(
                     qty,
                     worthCoin,
                     treasure?.getUuid()
@@ -161,16 +161,16 @@ const TreasureForm = ({
                     value={coinTreasure}
                     onChange={(e) => {
                         resetFields()
-                        setCoinTreasure(e.target.value as CoinTreasure)
+                        setCoinTreasure(e.target.value as CoinOrTreasure)
                     }}
                 >
-                    {getEnumKeys(CoinTreasure).map((key, index) => (
-                        <option key={index} value={CoinTreasure[key]}>
+                    {getEnumKeys(CoinOrTreasure).map((key, index) => (
+                        <option key={index} value={CoinOrTreasure[key]}>
                             {capitalize(key)}
                         </option>
                     ))}
                 </select>
-                {coinTreasure === CoinTreasure.treasure ? (
+                {coinTreasure === CoinOrTreasure.treasure ? (
                     <>
                         <label htmlFor="treasure-name">
                             Name{' '}

--- a/src/service/CharClass.ts
+++ b/src/service/CharClass.ts
@@ -1,10 +1,10 @@
-export enum Char_Class {
+export enum CharClass {
     cleric = 'cleric',
     dwarf = 'dwarf',
     elf = 'elf',
     fighter = 'fighter',
     halfling = 'halfling',
-    magic_user = 'Magic-User',
+    magicUser = 'Magic-User',
     thief = 'thief',
-    normal_human = 'normal human',
+    normalHuman = 'normal human',
 }

--- a/src/service/Character.ts
+++ b/src/service/Character.ts
@@ -1,108 +1,108 @@
 import { v4 as uuidv4 } from 'uuid'
-import { Char_Class } from './Char_Class'
+import { CharClass } from './CharClass'
 import { Denomination } from './Denomination'
-import { get_tpx_by_class_level } from './TXP'
+import { getTpxByClassLevel } from './TXP'
 
 export class Character {
     private name: string = ''
     private uuid: string
     private level: number = 0
-    private char_class: Char_Class = Char_Class.normal_human
-    private xp_mod: number = 0
+    private charClass: CharClass = CharClass.normalHuman
+    private xpMod: number = 0
     private pc: boolean = false
 
     constructor(
         name: string,
         level: number,
-        char_class: string,
-        xp_mod: number,
+        charClass: string,
+        xpMod: number,
         pc: boolean = true,
         uuid = uuidv4()
     ) {
         this.name = name
         this.uuid = uuid
         this.level = level
-        this.char_class = char_class as Char_Class
-        this.xp_mod = xp_mod
+        this.charClass = charClass as CharClass
+        this.xpMod = xpMod
         this.pc = pc
     }
 
-    get_name = (): string => {
+    getName = (): string => {
         return this.name
     }
 
-    get_uuid = (): string => {
+    getUuid = (): string => {
         return this.uuid
     }
 
-    get_level = (): number => {
+    getLevel = (): number => {
         return this.level
     }
 
-    get_char_class = (): Char_Class => {
-        return this.char_class
+    getCharClass = (): CharClass => {
+        return this.charClass
     }
 
-    get_xp_mod = (): number => {
-        return this.xp_mod
+    getXpMod = (): number => {
+        return this.xpMod
     }
 
-    get_xp_mod_percentage = (): number => {
-        return this.xp_mod / 100 + 1
+    getXpModPercentage = (): number => {
+        return this.xpMod / 100 + 1
     }
 
-    get_pc = (): boolean => {
+    getPc = (): boolean => {
         return this.pc
     }
 
-    to_string = (): string => {
-        return `name: ${this.name}; level: ${this.level}; class: ${this.char_class}; xp modifier: ${this.xp_mod}%; ${this.pc ? 'PC' : 'NPC'}`
+    toString = (): string => {
+        return `name: ${this.name}; level: ${this.level}; class: ${this.charClass}; xp modifier: ${this.xpMod}%; ${this.pc ? 'PC' : 'NPC'}`
     }
 
-    get_txp = (): number => {
-        return get_tpx_by_class_level(this.char_class, this.level)
+    getTxp = (): number => {
+        return getTpxByClassLevel(this.charClass, this.level)
     }
 }
 
 export class NPC extends Character {
     private wage: number
-    private wage_coin: Denomination
+    private wageCoin: Denomination
     private share: string
 
     constructor(
         name: string,
         level: number,
-        char_class: string,
-        xp_mod: number,
+        charClass: string,
+        xpMod: number,
         wage: number,
-        wage_coin: string,
+        wageCoin: string,
         share: string,
         uuid = uuidv4()
     ) {
-        super(name, level, char_class, xp_mod, false, uuid)
+        super(name, level, charClass, xpMod, false, uuid)
         this.wage = wage
-        this.wage_coin = wage_coin as Denomination
+        this.wageCoin = wageCoin as Denomination
         this.share = share
     }
 
-    get_wage = (): number => {
+    getWage = (): number => {
         return this.wage
     }
 
-    get_wage_coin = (): Denomination => {
-        return this.wage_coin
+    getWageCoin = (): Denomination => {
+        return this.wageCoin
     }
-    get_share = (): string => {
+    getShare = (): string => {
         return this.share
     }
 
-    to_string = (): string => {
-        return `name: ${this.get_name()}; level: ${this.get_level()}; class: ${this.get_char_class()}; xp modifier: ${this.get_xp_mod()}%; NPC; wage: ${this.get_wage()}${this.get_wage_coin()} daily; treasure share: ${this.get_share()}`
+    toString = (): string => {
+        return `name: ${this.getName()}; level: ${this.getLevel()}; class: ${this.getCharClass()}; xp modifier: ${this.getXpMod()}%; NPC; wage: ${this.getWage()}${this.getWageCoin()} daily; treasure share: ${this.getShare()}`
     }
 }
 
-// let my_character: Character = new Character('jon', 1, 'cleric', 10, true)
-// console.log(my_character.to_string())
+// let myCharacter: Character = new Character('jon', 1, 'cleric', 10, true)
+// console.log(myCharacter.toString())
 
 // let npc: NPC = new NPC('mikhail', 1, 'fighter', 0, 5, 'gp', '1/2')
-// console.log(npc.to_string())
+// console.log(npc.toString())

--- a/src/service/Monster.ts
+++ b/src/service/Monster.ts
@@ -21,7 +21,7 @@ export class Monster {
         this.qty = qty
     }
 
-    public get_name = (): string => {
+    public getName = (): string => {
         return this.name
     }
 
@@ -29,19 +29,19 @@ export class Monster {
         return this.uuid
     }
 
-    public get_description = (): string => {
+    public getDescription = (): string => {
         return this.description
     }
 
-    public get_xp = (): number => {
+    public getXp = (): number => {
         return this.xp
     }
 
-    public get_total_xp = (): number => {
+    public getTotalXp = (): number => {
         return this.xp * this.qty
     }
 
-    public get_qty = () => {
+    public getQty = () => {
         return this.qty
     }
 }

--- a/src/service/Party.ts
+++ b/src/service/Party.ts
@@ -259,7 +259,7 @@ export class Party {
         let total = 0
 
         for (let c of this.characters) {
-            total += c instanceof NPC ? this.xp_pc_share : this.xp_pc_share / 2
+            total += !(c instanceof NPC) ? this.xp_pc_share : this.xp_pc_share / 2
         }
 
         return total
@@ -295,6 +295,7 @@ export class Party {
         )
 
         this.num_shares = this.calculateShares()
+        this.num_shares = this.calculateXPShares()
         this.party_txp = this.calculatePartyTXP()
     }
 

--- a/src/service/Party.ts
+++ b/src/service/Party.ts
@@ -316,7 +316,7 @@ export class Party {
     }
 
     public getGpPerShare = (): number => {
-        return Math.round(this.getTreasureXp() / this.numShares)
+        return this.getTreasureXp() / this.numShares
     }
 
     public getGpPerPCShare = (): number => {

--- a/src/service/TXP.ts
+++ b/src/service/TXP.ts
@@ -1,13 +1,13 @@
-import { Char_Class } from './Char_Class'
+import { CharClass } from './CharClass'
 
-export let get_tpx_by_class_level = (
-    char_class: Char_Class,
+export let getTpxByClassLevel = (
+    charClass: CharClass,
     level: number
 ): number => {
     let result: number = 0
 
-    // const class_cube: number[][] = [[0, 1_500, 1_500, 3_000, 12_000, 13_000, 25_000, 50_000, 100_000, 100_000,], []]
-    if (char_class === Char_Class.cleric) {
+    // const classCube: number[][] = [[0, 1_500, 1_500, 3_000, 12_000, 13_000, 25_000, 50_000, 100_000, 100_000,], []]
+    if (charClass === CharClass.cleric) {
         switch (level) {
             case 1:
                 result = 1_500
@@ -49,7 +49,7 @@ export let get_tpx_by_class_level = (
                 result = 100_000
                 break
         }
-    } else if (char_class === Char_Class.dwarf) {
+    } else if (charClass === CharClass.dwarf) {
         switch (level) {
             case 1:
                 result = 2_200
@@ -85,7 +85,7 @@ export let get_tpx_by_class_level = (
                 result = 130_000
                 break
         }
-    } else if (char_class === Char_Class.elf) {
+    } else if (charClass === CharClass.elf) {
         switch (level) {
             case 1:
                 result = 4_000
@@ -115,7 +115,7 @@ export let get_tpx_by_class_level = (
                 result = 200_000
                 break
         }
-    } else if (char_class === Char_Class.fighter) {
+    } else if (charClass === CharClass.fighter) {
         switch (level) {
             case 1:
                 result = 2_000
@@ -157,7 +157,7 @@ export let get_tpx_by_class_level = (
                 result = 120_000
                 break
         }
-    } else if (char_class === Char_Class.halfling) {
+    } else if (charClass === CharClass.halfling) {
         switch (level) {
             case 1:
                 result = 2_000
@@ -181,7 +181,7 @@ export let get_tpx_by_class_level = (
                 result = 56_000
                 break
         }
-    } else if (char_class === Char_Class.magic_user) {
+    } else if (charClass === CharClass.magicUser) {
         switch (level) {
             case 1:
                 result = 2_500
@@ -223,7 +223,7 @@ export let get_tpx_by_class_level = (
                 result = 150_000
                 break
         }
-    } else if (char_class === Char_Class.thief) {
+    } else if (charClass === CharClass.thief) {
         switch (level) {
             case 1:
                 result = 1_200

--- a/src/service/ToClipboard.ts
+++ b/src/service/ToClipboard.ts
@@ -3,28 +3,28 @@ import { Denomination } from './Denomination'
 import { Determiner } from './Determiner'
 import { Monster } from './Monster'
 import { Party } from './Party'
-import { Coin_Treasure, Treasure } from './Treasure'
+import { CoinTreasure, Treasure } from './Treasure'
 
 export let ToClipboard = (party: Party): string => {
     let text = ''
 
     // Characters
-    if (party.get_characters().length > 0) {
+    if (party.getCharacters().length > 0) {
         text += `### Characters:\n\n`
         text += `${party.getNumPC()} PCs: (`
         let i = 0
-        for (let c of party.get_pcs()) {
-            text += `${c.get_name()}`
-            if (i !== party.get_pcs().length - 1) {
+        for (let c of party.getPcs()) {
+            text += `${c.getName()}`
+            if (i !== party.getPcs().length - 1) {
                 text += `, `
             }
             i++
         }
         i = 0
         text += `), ${party.getNumNPC()} NPCs: (`
-        for (let c of party.get_npcs()) {
-            text += `${c.get_name()} [share: ${c instanceof NPC ? c.get_share() : ''}]`
-            if (i !== party.get_npcs().length - 1) {
+        for (let c of party.getNpcs()) {
+            text += `${c.getName()} [share: ${c instanceof NPC ? c.getShare() : ''}]`
+            if (i !== party.getNpcs().length - 1) {
                 text += `, `
             }
             i++
@@ -34,60 +34,60 @@ export let ToClipboard = (party: Party): string => {
 
     // Monsters
 
-    const monsters: Array<Monster> = party.get_monsters()
+    const monsters: Array<Monster> = party.getMonsters()
     if (monsters.length > 0) {
         text += `### Monsters\n\n`
 
         for (let m of monsters) {
-            text += `- ${m.get_qty() > 1 ? m.get_qty() : ''} ${m.get_name()} (XP: ${m.get_xp()}${m.get_qty() > 1 ? ` each, ${m.get_total_xp()} total` : ''})\n`
+            text += `- ${m.getQty() > 1 ? m.getQty() : ''} ${m.getName()} (XP: ${m.getXp()}${m.getQty() > 1 ? ` each, ${m.getTotalXp()} total` : ''})\n`
         }
 
-        text += `\nTotal: ${party.get_monster_xp()} XP\n\n`
+        text += `\nTotal: ${party.getMonsterXp()} XP\n\n`
     }
 
     // Treasure
 
-    const treasure: Array<Treasure> = party.get_treasure()
+    const treasure: Array<Treasure> = party.getTreasure()
     if (treasure.length > 0) {
         text += `### Treasure\n\n`
 
         for (let t of treasure) {
             let worth: string
-            if (!(t instanceof Coin_Treasure)) {
-                worth = `worth ${t.getWorth()}${t.getWorth_coin()}${
+            if (!(t instanceof CoinTreasure)) {
+                worth = `worth ${t.getWorth()}${t.getWorthCoin()}${
                     t.getQty() > 1
-                        ? ` ${t.getWorth_determiner() === Determiner.each ? `${t.getWorth_determiner()},${t.getWorth() * t.getQty()}${t.getWorth_coin()}total` : ''}`
+                        ? ` ${t.getWorthDeterminer() === Determiner.each ? `${t.getWorthDeterminer()},${t.getWorth() * t.getQty()}${t.getWorthCoin()}total` : ''}`
                         : ''
                 }`
 
                 text += `- ${t.getQty() > 1 ? `${t.getQty()} ` : ''}${t.getName()}${t.getDescription().length > 0 ? `(${t.getDescription()})` : ''}${t.getWorth() > 0 ? `, (${worth})` : ''}\n`
             } else {
-                text += `- ${t.to_string()}${t.getWorth_coin() !== Denomination.gp ? ` (${t.to_gp(t.getQty(), t.getWorth_coin())}gp)` : ''}\n`
+                text += `- ${t.toString()}${t.getWorthCoin() !== Denomination.gp ? ` (${t.toGp(t.getQty(), t.getWorthCoin())}gp)` : ''}\n`
             }
         }
 
-        text += `\nTotal: ${party.get_treasure_xp()} XP/gp worth of treasure\n\n`
+        text += `\nTotal: ${party.getTreasureXp()} XP/gp worth of treasure\n\n`
     }
 
     // Feats
 
     text += `### Feats of Exploration\n\n`
-    text += `Party TXP: ${party.get_party_txp()}\n\n`
+    text += `Party TXP: ${party.getPartyTxp()}\n\n`
 
-    let feats = party.get_feats()
+    let feats = party.getFeats()
     for (let f of feats) {
-        text += `- ${f.getName()} (${f.getFeatLevel()})${f.getDescription().length > 1 ? ` - ${f.getDescription()}` : ''} - ${f.getXP(party.get_party_txp())} XP \n`
+        text += `- ${f.getName()} (${f.getFeatLevel()})${f.getDescription().length > 1 ? ` - ${f.getDescription()}` : ''} - ${f.getXP(party.getPartyTxp())} XP \n`
     }
 
-    text += `\nTotal: ${party.get_feat_xp()} XP\n\n`
+    text += `\nTotal: ${party.getFeatXp()} XP\n\n`
 
     // Totals
 
     text += `### Total\n\n`
-    text += `Total XP: ${party.get_total_xp()}\n\n`
-    text += `XP per PC: ${Math.round(party.get_xp_per_pc_share())}\n\n`
+    text += `Total XP: ${party.getTotalXp()}\n\n`
+    text += `XP per PC: ${Math.round(party.getXpPerPcShare())}\n\n`
     text += `Share of treasure per PC: ${party.getGpPerPCShare()}gp\n\n`
-    text += `XP per NPC: ${Math.round(party.get_xp_per_npc_share())}\n\n`
+    text += `XP per NPC: ${Math.round(party.getXpPerNpcShare())}\n\n`
     if (party.getNumNPC() > 0) {
         text += `Share of treasure per NPC:\n\n`
 

--- a/src/service/Treasure.ts
+++ b/src/service/Treasure.ts
@@ -13,8 +13,8 @@ export class Treasure {
     private description: string
     private qty: number
     private worth: number
-    private worth_coin: Denomination
-    private worth_determiner: Determiner
+    private worthCoin: Denomination
+    private worthDeterminer: Determiner
     private treasureType: TreasureType
 
     constructor(
@@ -22,8 +22,8 @@ export class Treasure {
         description: string,
         qty: number,
         worth: number,
-        worth_coin: string,
-        worth_determiner: string,
+        worthCoin: string,
+        worthDeterminer: string,
         uuid: string = uuidv4(),
         treasureType = TreasureType.treasure
     ) {
@@ -32,8 +32,8 @@ export class Treasure {
         this.description = description
         this.qty = qty
         this.worth = worth
-        this.worth_coin = worth_coin as Denomination
-        this.worth_determiner = worth_determiner as Determiner
+        this.worthCoin = worthCoin as Denomination
+        this.worthDeterminer = worthDeterminer as Determiner
         this.treasureType = treasureType as TreasureType
     }
 
@@ -73,59 +73,59 @@ export class Treasure {
         this.worth = worth
     }
 
-    public getWorth_coin(): Denomination {
-        return this.worth_coin
+    public getWorthCoin(): Denomination {
+        return this.worthCoin
     }
 
-    public setWorth_coin(worth_coin: Denomination): void {
-        this.worth_coin = worth_coin
+    public setWorthCoin(worthCoin: Denomination): void {
+        this.worthCoin = worthCoin
     }
 
-    public getWorth_determiner(): Determiner {
-        return this.worth_determiner
+    public getWorthDeterminer(): Determiner {
+        return this.worthDeterminer
     }
 
-    public setWorth_determiner(worth_determiner: Determiner): void {
-        this.worth_determiner = worth_determiner
+    public setWorthDeterminer(worthDeterminer: Determiner): void {
+        this.worthDeterminer = worthDeterminer
     }
 
-    to_string = (): string => {
-        return `${this.qty > 1 ? `${this.qty}x ` : ''}${this.name}${this.description.length > 0 ? `(${this.description})` : ''}${this.worth > 0 ? `, (worth ${this.worth}${this.worth_coin} ${this.worth_determiner})` : ''}`
+    toString = (): string => {
+        return `${this.qty > 1 ? `${this.qty}x ` : ''}${this.name}${this.description.length > 0 ? `(${this.description})` : ''}${this.worth > 0 ? `, (worth ${this.worth}${this.worthCoin} ${this.worthDeterminer})` : ''}`
     }
 
-    public get_xp = (): number => {
+    public getXp = (): number => {
         let xp: number = 0
-        let total_worth: number = 0
+        let totalWorth: number = 0
 
         // calculate total worth (in case of eaches)
-        if (this.worth_determiner === Determiner.total) {
-            total_worth = this.worth
-        } else if (this.worth_determiner === Determiner.each) {
-            total_worth = this.worth * this.qty
+        if (this.worthDeterminer === Determiner.total) {
+            totalWorth = this.worth
+        } else if (this.worthDeterminer === Determiner.each) {
+            totalWorth = this.worth * this.qty
         }
 
         // convert from different denominations to gp
-        switch (this.worth_coin) {
+        switch (this.worthCoin) {
             case Denomination.pp:
-                xp = total_worth * 5
+                xp = totalWorth * 5
                 break
             case Denomination.gp:
-                xp = total_worth
+                xp = totalWorth
                 break
             case Denomination.ep:
-                xp = total_worth / 2
+                xp = totalWorth / 2
                 break
             case Denomination.sp:
-                xp = total_worth / 10
+                xp = totalWorth / 10
                 break
             case Denomination.cp:
-                xp = total_worth / 100
+                xp = totalWorth / 100
         }
 
         return xp
     }
 
-    public to_gp = (n: number, c: Denomination): number => {
+    public toGp = (n: number, c: Denomination): number => {
         let worth = 0
 
         switch (c) {
@@ -149,10 +149,10 @@ export class Treasure {
     }
 }
 
-export class Coin_Treasure extends Treasure {
-    constructor(qty: number, worth_coin: string, uuid: string = uuidv4()) {
+export class CoinTreasure extends Treasure {
+    constructor(qty: number, worthCoin: string, uuid: string = uuidv4()) {
         let name = 'Gold'
-        switch (worth_coin) {
+        switch (worthCoin) {
             case 'pp':
                 name = 'Platinum'
                 break
@@ -174,20 +174,20 @@ export class Coin_Treasure extends Treasure {
             '',
             qty,
             qty,
-            worth_coin,
+            worthCoin,
             'total',
             uuid,
             TreasureType.coin
         )
     }
 
-    to_string = (): string => {
+    toString = (): string => {
         return `${this.getQty().toLocaleString()} ${this.getName()}`
     }
 }
 
-// console.log(new Treasure('gem', 'red ruby', 4, 25, 'gp', 'each').to_string())
-// console.log(new Coin_Treasure(1200, 'gp').to_string())
+// console.log(new Treasure('gem', 'red ruby', 4, 25, 'gp', 'each').toString())
+// console.log(new CoinTreasure(1200, 'gp').toString())
 // console.log(
 //     new Treasure(
 //         'sword',
@@ -196,5 +196,5 @@ export class Coin_Treasure extends Treasure {
 //         0,
 //         'gp',
 //         'each'
-//     ).to_string()
+//     ).toString()
 // )


### PR DESCRIPTION
Fixed XP calculation. the function `calculateXPShares()` was doing the operations for NPCs to PCs, and viceversa, making it so when the constructor was called when cloning the Party object, the incorrect amount of number of xp shares was saved, throwing the rest of the calculations off.